### PR TITLE
Release/3.31.0 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### v3.31.0 (Jun 20, 2025)
+
+# SendbirdUIKit
+### Improvements and Deprecations
+We have fixed autolayout warnings. 
+In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
+Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
+- `open func register(adminMessageCell:nib:)`
+- `open func register(userMessageCell:nib:)` 
+- `open func register(fileMessageCell:nib:)` 
+- `open func register(multipleFilesMessageCell:nib:)` 
+- `open func register(typingIndicatorMessageCell:nib:)` 
+- `open func register(unknownMessageCell:nib:)`   
+- `open func register(customMessageCell:nib:)`     
+
+# SendbirdUIMessageTemplate
+- none
+
 ### v3.30.2 (May 19, 2025)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.30.2/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "e293b07b0b695f0848f3d45ec83eff5687fcfdc48d58e6f9715b86d4e3bc2984" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "64726c2b7b655671adeb15229c9d3fa4b8b1263d5d4fdbbf86bfa1039427ac30" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.30.2/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "f218902a6b1fbc40127b24dc3c8156da4829079e90d6c939f6ac1643f4fe968f" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "c5943e894d0d5bfc15485614a929d6e630fe3b2f830ea6efe99468d66688c41e" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",


### PR DESCRIPTION
# SendbirdUIKit
### Improvements and Deprecations
We have fixed autolayout warnings. 
In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
- `open func register(adminMessageCell:nib:)`
- `open func register(userMessageCell:nib:)` 
- `open func register(fileMessageCell:nib:)` 
- `open func register(multipleFilesMessageCell:nib:)` 
- `open func register(typingIndicatorMessageCell:nib:)` 
- `open func register(unknownMessageCell:nib:)`   
- `open func register(customMessageCell:nib:)`     

# SendbirdUIMessageTemplate
- none