### PR TITLE
Release/1.0.999 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v1.0.999 (Jul 24, 2025)
+
+# SendbirdUIKit
+### Improvements and Deprecations
+testing...     
+
+# SendbirdUIMessageTemplate
+- none
+
 ### v3.31.0 (Jun 20, 2025)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "64726c2b7b655671adeb15229c9d3fa4b8b1263d5d4fdbbf86bfa1039427ac30" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/1.0.999/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "cb526ef087b255ce299de454490ebb4be45af25983fe5566bff9272b35d010ee" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.31.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "c5943e894d0d5bfc15485614a929d6e630fe3b2f830ea6efe99468d66688c41e" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/1.0.999/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "2fee4293fbc3a9832fdf9b9f439dd39d5443cafdbc35396e9be299cacd32db4c" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",


### PR DESCRIPTION
# SendbirdUIKit
### Improvements and Deprecations
We have fixed autolayout warnings. 
In the process, we have improved message cell types to be registered based on Metatypes, instead of instances. 
Accordingly, the below interfaces in `SBUGroupChannelModule.List` have been deprecated. 
- `open func register(adminMessageCell:nib:)`
- `open func register(userMessageCell:nib:)` 
- `open func register(fileMessageCell:nib:)` 
- `open func register(multipleFilesMessageCell:nib:)` 
- `open func register(typingIndicatorMessageCell:nib:)` 
- `open func register(unknownMessageCell:nib:)`   
- `open func register(customMessageCell:nib:)`     

# SendbirdUIMessageTemplate
- none