### PR TITLE
Release/3.34.0 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+### v3.34.0 (Feb 13, 2026)
+
+# SendbirdUIKit
+
+## New Feature
+### Liquid Glass Support (iOS 26+)
+
+SendbirdUIKit now supports Apple's Liquid Glass design introduced in iOS 26. When running on iOS 26+, liquid glass styling is applied automatically across navigation bars, message input views, alert views, menus, and channel list headers.
+
+**Opting Out**
+
+Liquid glass is enabled by default on iOS 26+. To disable it and use the classic appearance:
+```swift
+  SendbirdUI.config.common.isLiquidGlassEnabled = false
+```
+
+**What's Affected**
+The below components have been updated to support liquid glass styling:
+- Navigation bars
+- Message input view
+- Alert views
+- Menu views (for when long-pressing messages)
+- "Create channel" context menu in GroupChannelList Header
 ### v3.33.1 (Feb 03, 2026)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,13 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.1/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "b55c89d32f9634270be305c92fc67c0c0b04c23328d4f9436e55037dce3ec9ca" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "fbc41adc410b034454fe2b507a0c6b5bbb42c4f4963c438951c94c0a46c39cca" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.1/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "99be28b7f9e23a5749f28565362a335e709d2752fada6af15032879882f69542" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "8fb8dd6c05ce84eab5754ed91da7f5ef5e104d60e39ef75c4f995cc618b693f4" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",


### PR DESCRIPTION
# SendbirdUIKit

## New Feature
### Liquid Glass Support (iOS 26+)

SendbirdUIKit now supports Apple's Liquid Glass design introduced in iOS 26. When running on iOS 26+, liquid glass styling is applied automatically across navigation bars, message input views, alert views, menus, and channel list headers.

**Opting Out**

Liquid glass is enabled by default on iOS 26+. To disable it and use the classic appearance:
```swift
  SendbirdUI.config.common.isLiquidGlassEnabled = false
```

**What's Affected**
The below components have been updated to support liquid glass styling:
- Navigation bars
- Message input view
- Alert views
- Menu views (for when long-pressing messages)
- "Create channel" context menu in GroupChannelList Header