### PR TITLE
Release/3.34.1 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### v3.34.1 (Apr 08, 2026)
+
+### Build Environment
+
+- Rebuilt with **Xcode 26** to comply with Apple's App Store submission requirement,
+  effective late April 2026, which mandates that all apps be built using Xcode 26 or later.
+- No functional changes or API modifications are included in this release.
+
+> **Note for Xcode 16 users:** This release is compiled with Xcode 26 and may not be
+> compatible with Xcode 16 build environments. If you are still on Xcode 16, please
+> continue using the previous version.
+
 ### v3.34.0 (Feb 13, 2026)
 
 # SendbirdUIKit

--- a/Package.swift
+++ b/Package.swift
@@ -20,19 +20,19 @@ let package = Package(
         .package(
             name: "SendbirdChatSDK",
             url: "https://github.com/sendbird/sendbird-chat-sdk-ios",
-            from: "4.35.0"
+            from: "4.38.2"
         ),
     ],
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "fbc41adc410b034454fe2b507a0c6b5bbb42c4f4963c438951c94c0a46c39cca" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.1/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "0ffc6a09e091a3c7b23049e4a27dd9df0749dce4b7017316685aa541a6ebcc5a" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "8fb8dd6c05ce84eab5754ed91da7f5ef5e104d60e39ef75c4f995cc618b693f4" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.1/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "3fceb11dc50db7581637f9361a150d10a98fe9b17ffb29d9087984989e7bb686" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The minimum requirements for Sendbird UIKit for iOS are:
 
 - iOS 13+
 - Swift 5.10+
-- Sendbird Chat SDK for iOS 4.35.0+
+- Sendbird Chat SDK for iOS 4.38.2+
 
 <br />
 


### PR DESCRIPTION
### Build Environment

- Rebuilt with **Xcode 26** to comply with Apple's App Store submission requirement,
  effective late April 2026, which mandates that all apps be built using Xcode 26 or later.
- No functional changes or API modifications are included in this release.

> **Note for Xcode 16 users:** This release is compiled with Xcode 26 and may not be
> compatible with Xcode 16 build environments. If you are still on Xcode 16, please
> continue using the previous version.