### PR TITLE
Release/3.35.2 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@
 - Legacy `LogType` bitmask `{none, error, warning, info, all}` maps to `AuthLogLevel` as `none / warning / error / info`. UIKit does not produce `verbose` or `debug` output. (#1407)
 - Once `SendbirdLogger.setLevel(...)` has been called, `SendbirdUI.setLogLevel(_:)` is ignored. (#1407)
 
+### v3.35.2 (May 14, 2026)
+
+### Added
+- UIKit and MessageTemplate logging is now routed through the shared `SendbirdLogger` (`Logger.uikit`, `Logger.messageTemplate`) and emitted in the unified Sendbird log format. (#1407)
+- `Log.info(...)` / `Log.warn(...)` / `Log.error(...)` helpers used throughout UIKit internals. (#1407)
+
+### Deprecated
+- `SendbirdUI.setLogLevel(_:)` (both the single `LogType` and `[LogType]` bitmask variants) — use `SendbirdLogger.setLevel(_:)` or `SendbirdLogger.setLevel(_:for: .uikit)` instead. Existing calls are forwarded to a compatibility setter and continue to work. (#1407)
+
+### Changed
+- `SBULog.logType` is no longer a local bitmask flag; it reads/writes through `SendbirdLogger` as the single source of truth. (#1407)
+- Legacy `LogType` bitmask `{none, error, warning, info, all}` maps to `AuthLogLevel` as `none / warning / error / info`. UIKit does not produce `verbose` or `debug` output. (#1407)
+- Once `SendbirdLogger.setLevel(...)` has been called, `SendbirdUI.setLogLevel(_:)` is ignored. (#1407)
+
 ### v3.35.1 (Apr 24, 2026)
 
 ### Improvements

--- a/Package.swift
+++ b/Package.swift
@@ -27,12 +27,12 @@ let package = Package(
         .binaryTarget(
             name: "SendbirdUIKit",
             url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.2/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "8f84372497294382ead18e17236e3fec6fcbaa99331cefc740020090e9262e47" // SendbirdUIKit_CHECKSUM
+            checksum: "4b95d8cbb7627f9d16308d10174adb32887d7562b39446e2ef3ad8d63f3ed662" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
             url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.2/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "582fa61f15589bc404673d44c1807b30071658a7f1d5e68ba1f39a01806b28ea" // SendbirdUIMessageTemplate_CHECKSUM
+            checksum: "b761a839710cc51e83206be867d57545d8d4746e9c971424bfcd3f407169f37d" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",


### PR DESCRIPTION
### Added
- UIKit and MessageTemplate logging is now routed through the shared `SendbirdLogger` (`Logger.uikit`, `Logger.messageTemplate`) and emitted in the unified Sendbird log format. (#1407)
- `Log.info(...)` / `Log.warn(...)` / `Log.error(...)` helpers used throughout UIKit internals. (#1407)

### Deprecated
- `SendbirdUI.setLogLevel(_:)` (both the single `LogType` and `[LogType]` bitmask variants) — use `SendbirdLogger.setLevel(_:)` or `SendbirdLogger.setLevel(_:for: .uikit)` instead. Existing calls are forwarded to a compatibility setter and continue to work. (#1407)

### Changed
- `SBULog.logType` is no longer a local bitmask flag; it reads/writes through `SendbirdLogger` as the single source of truth. (#1407)
- Legacy `LogType` bitmask `{none, error, warning, info, all}` maps to `AuthLogLevel` as `none / warning / error / info`. UIKit does not produce `verbose` or `debug` output. (#1407)
- Once `SendbirdLogger.setLevel(...)` has been called, `SendbirdUI.setLogLevel(_:)` is ignored. (#1407)