### PR TITLE
Release/3.35.4 -> main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### v3.35.4 (Jun 25, 2026)
+
+### Improvements
+
+- Improved the Liquid Glass navigation bar to better match the iOS 26 native look. (CLNP-8629) (#1428)
+- Fixed an issue in Liquid Glass mode where the reaction emoji picker and the long-press menu sheet appeared with a transparent background. (CLNP-8641) (#1429)
+- Fixed an issue where emojis the current user had already reacted with were not shown as highlighted in the emoji picker and in the long-press action sheet's reaction row. (CLNP-8611) (#1430)
+- Updated `SendbirdChatSDK` dependency to 4.39.6.
+
 ### v3.35.3 (May 21, 2026)
 
 ### Improvements

--- a/Package.swift
+++ b/Package.swift
@@ -20,19 +20,19 @@ let package = Package(
         .package(
             name: "SendbirdChatSDK",
             url: "https://github.com/sendbird/sendbird-chat-sdk-ios",
-            from: "4.39.4"
+            from: "4.39.6"
         ),
     ],
     targets: [
         .binaryTarget(
             name: "SendbirdUIKit",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.3/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
-            checksum: "cce7ca2698cd357b1d0750a7cd3b44322d4bca75c711eb4ca8285112988ceb3c" // SendbirdUIKit_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.4/SendbirdUIKit.xcframework.zip", // SendbirdUIKit_URL
+            checksum: "685bf855d2f69199d08f05bb57c774657c35c13e02fb45dbf3d263f147b8e021" // SendbirdUIKit_CHECKSUM
         ),
         .binaryTarget(
             name: "SendbirdUIMessageTemplate",
-            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.3/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
-            checksum: "84849a2075be26f0ddc3196f052e7df3b95232645e0a5fcf378c6f1fc857f841" // SendbirdUIMessageTemplate_CHECKSUM
+            url: "https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.4/SendbirdUIMessageTemplate.xcframework.zip", // SendbirdUIMessageTemplate_URL
+            checksum: "1a71193ca4f3d204afb593c5d1e0f2cba78a23ba2b83b512c9224cd246658858" // SendbirdUIMessageTemplate_CHECKSUM
         ),
         .target(
             name: "SendbirdUIKitTarget",

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The minimum requirements for Sendbird UIKit for iOS are:
 
 - iOS 13+
 - Swift 5.10+
-- Sendbird Chat SDK for iOS 4.39.4+
+- Sendbird Chat SDK for iOS 4.39.6+
 
 <br />
 


### PR DESCRIPTION
### Improvements

- Improved the Liquid Glass navigation bar to better match the iOS 26 native look. (CLNP-8629) (#1428)
- Fixed an issue in Liquid Glass mode where the reaction emoji picker and the long-press menu sheet appeared with a transparent background. (CLNP-8641) (#1429)
- Fixed an issue where emojis the current user had already reacted with were not shown as highlighted in the emoji picker and in the long-press action sheet's reaction row. (CLNP-8611) (#1430)
- Updated `SendbirdChatSDK` dependency to 4.39.6.