### PR TITLE
fix: remove deprecated name parameter from package dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,24 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "SendbirdChatSDK",
-        "repositoryURL": "https://github.com/sendbird/sendbird-chat-sdk-ios",
-        "state": {
-          "branch": null,
-          "revision": "0b1843060748c295b49f60a6f718dc6488e11657",
-          "version": "4.24.1"
-        }
+  "originHash" : "fb1a0e4ed3f6c6fff7354bc9baeba7a7966ab0e2a1758b7b2261b53fbe27ffdf",
+  "pins" : [
+    {
+      "identity" : "sendbird-auth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sendbird/sendbird-auth-ios.git",
+      "state" : {
+        "revision" : "2d844ec87408327ac04b35c7298fe2658215e31b",
+        "version" : "1.1.3"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "sendbird-chat-sdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sendbird/sendbird-chat-sdk-ios",
+      "state" : {
+        "revision" : "92e749a807bcd910adefa0693fa1876750fddb6b",
+        "version" : "4.39.7"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            name: "SendbirdChatSDK",
             url: "https://github.com/sendbird/sendbird-chat-sdk-ios",
             from: "4.39.6"
         ),
@@ -39,7 +38,7 @@ let package = Package(
             dependencies: [
                 .target(name: "SendbirdUIKit"),
                 .target(name: "SendbirdUIMessageTemplate"),
-                .product(name: "SendbirdChatSDK", package: "SendbirdChatSDK")
+                .product(name: "SendbirdChatSDK", package: "sendbird-chat-sdk-ios")
             ],
             path: "Framework/Dependency",
             exclude: ["../../Sources"]
@@ -48,7 +47,7 @@ let package = Package(
             name: "SendbirdUIMessageTemplateTarget",
             dependencies: [
                 .target(name: "SendbirdUIMessageTemplate"),
-                .product(name: "SendbirdChatSDK", package: "SendbirdChatSDK")
+                .product(name: "SendbirdChatSDK", package: "sendbird-chat-sdk-ios")
             ],
             path: "Framework/Module/MessageTemplate",
             exclude: ["../../Sample", "../../Sources"]


### PR DESCRIPTION
`package(name:url:from:)` is deprecated in Swift Package Manager. 
Replace with package(url:from:); the name parameter is no longer needed as SPM resolves packages by URL.